### PR TITLE
Ignore permission requests from other plugins

### DIFF
--- a/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
+++ b/android/src/main/java/com/mr/flutter/plugin/filepicker/FilePickerDelegate.java
@@ -122,6 +122,13 @@ public class FilePickerDelegate implements PluginRegistry.ActivityResultListener
 
     @Override
     public boolean onRequestPermissionsResult(final int requestCode, final String[] permissions, final int[] grantResults) {
+        
+        // don't handle requests from other sources
+        if(REQUEST_CODE != requestCode){
+            return false;
+        }
+
+        
         final boolean permissionGranted =
                 grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
 


### PR DESCRIPTION
In my app, the file picker popup was getting triggered from use of the permission_handler plugin to request WRITE_EXTERNAL_STORAGE permissions.

This small change checks if `requestCode` matches file_picker's own code, and ignores the call to `onRequestPermissionsResult` if they don't match.